### PR TITLE
Add NLBs for FTP and forwarding to existing ALBs

### DIFF
--- a/groups/chd-infrastructure/asg_backend.tf
+++ b/groups/chd-infrastructure/asg_backend.tf
@@ -82,7 +82,8 @@ module "bep_asg" {
   name = "${var.application}-bep"
   # Launch configuration
   lc_name       = "${var.application}-bep-launchconfig"
-  image_id      = data.aws_ami.chd_bep_ami.id
+#  image_id      = data.aws_ami.chd_bep_ami.id
+  image_id      = "ami-0547185dcbc10ccf0"
   instance_type = var.bep_instance_size
   security_groups = [
     module.chd_bep_asg_security_group.this_security_group_id,

--- a/groups/chd-infrastructure/asg_backend.tf
+++ b/groups/chd-infrastructure/asg_backend.tf
@@ -82,8 +82,7 @@ module "bep_asg" {
   name = "${var.application}-bep"
   # Launch configuration
   lc_name       = "${var.application}-bep-launchconfig"
-#  image_id      = data.aws_ami.chd_bep_ami.id
-  image_id      = "ami-0547185dcbc10ccf0"
+  image_id      = data.aws_ami.chd_bep_ami.id
   instance_type = var.bep_instance_size
   security_groups = [
     module.chd_bep_asg_security_group.this_security_group_id,

--- a/groups/chd-infrastructure/locals.tf
+++ b/groups/chd-infrastructure/locals.tf
@@ -50,6 +50,9 @@ locals {
     }
   ] : []
 
+  # Define the NLB FTP target group ARNs (index 0) for ASG registration
+  chd_fe_internal_ftp_target_group_arn = [module.nlb_fe_internal.target_group_arns[0]]
+  chd_fe_external_ftp_target_group_arn = [module.nlb_fe_external.target_group_arns[0]]
 
   chd_fe_ansible_inputs = {
     s3_bucket_releases         = local.s3_releases["release_bucket_name"]

--- a/groups/chd-infrastructure/nlb_fe_external.tf
+++ b/groups/chd-infrastructure/nlb_fe_external.tf
@@ -1,0 +1,102 @@
+data "aws_network_interface" "nlb_fe_external" {
+  for_each = data.aws_subnet_ids.public.ids
+
+  filter {
+    name   = "description"
+    values = ["ELB ${module.nlb_fe_external.this_lb_arn_suffix}"]
+  }
+
+  filter {
+    name   = "subnet-id"
+    values = [each.value]
+  }
+}
+
+module "nlb_fe_external" {
+  source  = "terraform-aws-modules/alb/aws"
+  version = "~> 5.0"
+
+  name                       = "nlb-${var.application}-fe-external-001"
+  vpc_id                     = data.aws_vpc.vpc.id
+  internal                   = false
+  load_balancer_type         = "network"
+  enable_deletion_protection = true
+
+  subnets                    = data.aws_subnet_ids.public.ids
+
+  http_tcp_listeners = [
+    {
+      port               = 21
+      protocol           = "TCP"
+      target_group_index = 0
+    },
+    {
+      port               = 80
+      protocol           = "TCP"
+      target_group_index = 1
+    },
+    {
+      port               = 443
+      protocol           = "TCP"
+      target_group_index = 2
+    }
+  ]
+
+  target_groups = [
+    {
+      name                 = "tg-${var.application}-fe-external-ftp-001"
+      backend_protocol     = "TCP"
+      backend_port         = 21
+      target_type          = "instance"
+      deregistration_delay = 10
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 21
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "TCP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    },
+    {
+      name                 = "tg-${var.application}-fe-external-alb-001"
+      backend_protocol     = "TCP"
+      backend_port         = 80
+      target_type          = "alb"
+      targets = [
+        {
+          target_id        = module.chd_external_alb.this_lb_arn
+          port             = 80
+        }
+      ]
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    },
+    {
+      name                 = "tg-${var.application}-fe-external-alb-002"
+      backend_protocol     = "TCP"
+      backend_port         = 443
+      target_type          = "alb"
+      targets = [
+        {
+          target_id        = module.chd_external_alb.this_lb_arn
+          port             = 443
+        }
+      ]
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    }
+  ]
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "${upper(var.application)}-FE-Support"
+    )
+  )
+}

--- a/groups/chd-infrastructure/nlb_fe_internal.tf
+++ b/groups/chd-infrastructure/nlb_fe_internal.tf
@@ -1,0 +1,102 @@
+data "aws_network_interface" "nlb_fe_internal" {
+  for_each = data.aws_subnet_ids.web.ids
+
+  filter {
+    name   = "description"
+    values = ["ELB ${module.nlb_fe_internal.this_lb_arn_suffix}"]
+  }
+
+  filter {
+    name   = "subnet-id"
+    values = [each.value]
+  }
+}
+
+module "nlb_fe_internal" {
+  source  = "terraform-aws-modules/alb/aws"
+  version = "~> 5.0"
+
+  name                       = "nlb-${var.application}-fe-internal-001"
+  vpc_id                     = data.aws_vpc.vpc.id
+  internal                   = true
+  load_balancer_type         = "network"
+  enable_deletion_protection = true
+
+  subnets                    = data.aws_subnet_ids.web.ids
+
+  http_tcp_listeners = [
+    {
+      port               = 21
+      protocol           = "TCP"
+      target_group_index = 0
+    },
+    {
+      port               = 80
+      protocol           = "TCP"
+      target_group_index = 1
+    },
+    {
+      port               = 443
+      protocol           = "TCP"
+      target_group_index = 2
+    }
+  ]
+
+  target_groups = [
+    {
+      name                 = "tg-${var.application}-fe-internal-ftp-001"
+      backend_protocol     = "TCP"
+      backend_port         = 21
+      target_type          = "instance"
+      deregistration_delay = 10
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 21
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "TCP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    },
+    {
+      name                 = "tg-${var.application}-fe-internal-alb-001"
+      backend_protocol     = "TCP"
+      backend_port         = 80
+      target_type          = "alb"
+      targets = [
+        {
+          target_id        = module.chd_internal_alb.this_lb_arn
+          port             = 80
+        }
+      ]
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    },
+    {
+      name                 = "tg-${var.application}-fe-internal-alb-002"
+      backend_protocol     = "TCP"
+      backend_port         = 443
+      target_type          = "alb"
+      targets = [
+        {
+          target_id        = module.chd_internal_alb.this_lb_arn
+          port             = 443
+        }
+      ]
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    }
+  ]
+
+  tags = merge(
+    local.default_tags,
+    map(
+      "ServiceTeam", "${upper(var.application)}-FE-Support"
+    )
+  )
+}

--- a/groups/chd-infrastructure/outputs.tf
+++ b/groups/chd-infrastructure/outputs.tf
@@ -1,5 +1,5 @@
 output "chd_frontend_address_internal" {
-  value = aws_route53_record.chd_alb_internal.fqdn
+  value = aws_route53_record.chd_frontend_internal.fqdn
 }
 
 output "chd_bep_address_internal" {

--- a/groups/chd-infrastructure/route53.tf
+++ b/groups/chd-infrastructure/route53.tf
@@ -10,14 +10,14 @@ resource "aws_route53_record" "nlb_backend" {
   }
 }
 
-resource "aws_route53_record" "chd_alb_internal" {
+resource "aws_route53_record" "chd_frontend_internal" {
   zone_id = data.aws_route53_zone.private_zone.zone_id
   name    = var.application
   type    = "A"
 
   alias {
-    name                   = module.chd_internal_alb.this_lb_dns_name
-    zone_id                = module.chd_internal_alb.this_lb_zone_id
+    name                   = module.nlb_fe_internal.this_lb_dns_name
+    zone_id                = module.nlb_fe_internal.this_lb_zone_id
     evaluate_target_health = true
   }
 }


### PR DESCRIPTION
Added new NLB resources to sit in front of the existing ALB
 * Permit FTP access on port 21
 * Forward HTTP on port 80 to existing ALB
 * Forward HTTPS on port 443 to existing ALB
Added new local vars to define the ARNs for the NLB FTP Target Groups
Updated frontend ASG to permit FTP access on port 21 via the NLBs
Updated frontend ASG to additionallyt register instances to NLB FTP Target Groups
Updated Route53 resource to use NLB hostname instead of ALB
Updated outputs to use updated Route53 resource
