### PR TITLE
Allow HTTP and HTTPS from NLB, update NLB health checks, update FTP target groups and define target group stickyness.

### DIFF
--- a/groups/chd-infrastructure/alb_external.tf
+++ b/groups/chd-infrastructure/alb_external.tf
@@ -9,7 +9,11 @@ module "chd_external_alb_security_group" {
   description = "Security group for the ${var.application} web servers"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = var.fe_public_access_cidrs
+  ingress_cidr_blocks = concat(
+    var.fe_public_access_cidrs,
+    formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_external : eni.private_ip])
+  )
+
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
   egress_rules        = ["all-all"]
 }

--- a/groups/chd-infrastructure/alb_internal.tf
+++ b/groups/chd-infrastructure/alb_internal.tf
@@ -9,7 +9,11 @@ module "chd_internal_alb_security_group" {
   description = "Security group for the ${var.application} web servers"
   vpc_id      = data.aws_vpc.vpc.id
 
-  ingress_cidr_blocks = local.admin_cidrs
+  ingress_cidr_blocks = concat(
+    local.admin_cidrs,
+    formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_internal : eni.private_ip])
+  )
+
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]
 
   ingress_with_cidr_blocks = local.fe_alb_app_access

--- a/groups/chd-infrastructure/asg_frontend.tf
+++ b/groups/chd-infrastructure/asg_frontend.tf
@@ -154,8 +154,13 @@ module "fe_asg" {
   target_group_arns              = concat(
     module.chd_external_alb.target_group_arns,
     module.chd_internal_alb.target_group_arns,
-    local.chd_fe_internal_ftp_target_group_arn,
-    local.chd_fe_external_ftp_target_group_arn
+    flatten(
+      [
+        for num in range(2, length(module.nlb_fe_internal.target_group_arns)) : [
+          [module.nlb_fe_internal.target_group_arns[num], module.nlb_fe_external.target_group_arns[num]]
+        ]
+      ]
+    )
   )
 
   iam_instance_profile           = module.chd_fe_profile.aws_iam_instance_profile.name

--- a/groups/chd-infrastructure/asg_frontend.tf
+++ b/groups/chd-infrastructure/asg_frontend.tf
@@ -139,7 +139,8 @@ module "fe_asg" {
   # Auto scaling group
   asg_name                       = "${var.application}-fe-asg"
   vpc_zone_identifier            = data.aws_subnet_ids.web.ids
-  health_check_type              = "ELB"
+#  health_check_type              = "ELB"
+  health_check_type              = "EC2"
   min_size                       = var.fe_asg_min_size
   max_size                       = var.fe_asg_max_size
   desired_capacity               = var.fe_asg_desired_capacity

--- a/groups/chd-infrastructure/locals.tf
+++ b/groups/chd-infrastructure/locals.tf
@@ -50,10 +50,6 @@ locals {
     }
   ] : []
 
-  # Define the NLB FTP target group ARNs (index 2) for ASG registration
-  chd_fe_internal_ftp_target_group_arn = [module.nlb_fe_internal.target_group_arns[2]]
-  chd_fe_external_ftp_target_group_arn = [module.nlb_fe_external.target_group_arns[2]]
-
   # Generate listener configuration for FTP passive ports
   chd_fe_ftp_passive_listeners = [
     for num in range(var.fe_ftp_passive_ports_start, var.fe_ftp_passive_ports_end) : {

--- a/groups/chd-infrastructure/locals.tf
+++ b/groups/chd-infrastructure/locals.tf
@@ -75,10 +75,6 @@ locals {
         unhealthy_threshold = 3
         protocol            = "TCP"
       }
-      stickiness = {
-        type    = "source_ip"
-        enabled = true
-      }
       tags = {
         InstanceTargetGroupTag = var.application
       }
@@ -100,10 +96,6 @@ locals {
         healthy_threshold   = 3
         unhealthy_threshold = 3
         protocol            = "TCP"
-      }
-      stickiness = {
-        type    = "source_ip"
-        enabled = true
       }
       tags = {
         InstanceTargetGroupTag = var.application

--- a/groups/chd-infrastructure/locals.tf
+++ b/groups/chd-infrastructure/locals.tf
@@ -50,16 +50,60 @@ locals {
     }
   ] : []
 
-  # Define the NLB FTP target group ARNs (index 0) for ASG registration
-  chd_fe_internal_ftp_target_group_arn = [module.nlb_fe_internal.target_group_arns[0]]
-  chd_fe_external_ftp_target_group_arn = [module.nlb_fe_external.target_group_arns[0]]
+  # Define the NLB FTP target group ARNs (index 2) for ASG registration
+  chd_fe_internal_ftp_target_group_arn = [module.nlb_fe_internal.target_group_arns[2]]
+  chd_fe_external_ftp_target_group_arn = [module.nlb_fe_external.target_group_arns[2]]
 
   # Generate listener configuration for FTP passive ports
   chd_fe_ftp_passive_listeners = [
     for num in range(var.fe_ftp_passive_ports_start, var.fe_ftp_passive_ports_end) : {
       port               = format("%d", num)
       protocol           = "TCP"
-      target_group_index = 0
+    }
+  ]
+
+  # Generate target group configuration for FTP passive ports
+  # Internal NLB TGs
+  chd_fe_internal_ftp_passive_tgs = [
+    for num in range(var.fe_ftp_passive_ports_start, var.fe_ftp_passive_ports_end) : {
+      name                 = "tg-${var.application}-fe-int-ftp-${num}"
+      backend_protocol     = "TCP"
+      backend_port         = num
+      target_type          = "instance"
+      deregistration_delay = 10
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 21
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "TCP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    }
+  ]
+
+  # External NLB TGs
+  chd_fe_external_ftp_passive_tgs = [
+    for num in range(var.fe_ftp_passive_ports_start, var.fe_ftp_passive_ports_end) : {
+      name                 = "tg-${var.application}-fe-ext-ftp-${num}"
+      backend_protocol     = "TCP"
+      backend_port         = num
+      target_type          = "instance"
+      deregistration_delay = 10
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 21
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "TCP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
     }
   ]
 

--- a/groups/chd-infrastructure/locals.tf
+++ b/groups/chd-infrastructure/locals.tf
@@ -75,6 +75,10 @@ locals {
         unhealthy_threshold = 3
         protocol            = "TCP"
       }
+      stickiness = {
+        type    = "source_ip"
+        enabled = true
+      }
       tags = {
         InstanceTargetGroupTag = var.application
       }
@@ -96,6 +100,10 @@ locals {
         healthy_threshold   = 3
         unhealthy_threshold = 3
         protocol            = "TCP"
+      }
+      stickiness = {
+        type    = "source_ip"
+        enabled = true
       }
       tags = {
         InstanceTargetGroupTag = var.application

--- a/groups/chd-infrastructure/nlb_fe_external.tf
+++ b/groups/chd-infrastructure/nlb_fe_external.tf
@@ -26,42 +26,24 @@ module "nlb_fe_external" {
 
   http_tcp_listeners = concat([
     {
-      port               = 21
+      port               = 80
       protocol           = "TCP"
       target_group_index = 0
     },
     {
-      port               = 80
+      port               = 443
       protocol           = "TCP"
       target_group_index = 1
     },
     {
-      port               = 443
+      port               = 21
       protocol           = "TCP"
       target_group_index = 2
     }
   ],
   local.chd_fe_ftp_passive_listeners)
 
-  target_groups = [
-    {
-      name                 = "tg-${var.application}-fe-external-ftp-001"
-      backend_protocol     = "TCP"
-      backend_port         = 21
-      target_type          = "instance"
-      deregistration_delay = 10
-      health_check = {
-        enabled             = true
-        interval            = 30
-        port                = 21
-        healthy_threshold   = 3
-        unhealthy_threshold = 3
-        protocol            = "TCP"
-      }
-      tags = {
-        InstanceTargetGroupTag = var.application
-      }
-    },
+  target_groups = concat([
     {
       name                 = "tg-${var.application}-fe-external-alb-001"
       backend_protocol     = "TCP"
@@ -107,8 +89,27 @@ module "nlb_fe_external" {
       tags = {
         InstanceTargetGroupTag = var.application
       }
-    }
-  ]
+    },
+    {
+      name                 = "tg-${var.application}-fe-external-ftp-001"
+      backend_protocol     = "TCP"
+      backend_port         = 21
+      target_type          = "instance"
+      deregistration_delay = 10
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 21
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "TCP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
+    },
+  ],
+  local.chd_fe_external_ftp_passive_tgs)
 
   tags = merge(
     local.default_tags,

--- a/groups/chd-infrastructure/nlb_fe_external.tf
+++ b/groups/chd-infrastructure/nlb_fe_external.tf
@@ -104,10 +104,6 @@ module "nlb_fe_external" {
         unhealthy_threshold = 3
         protocol            = "TCP"
       }
-      stickiness = {
-        type    = "source_ip"
-        enabled = true
-      }
       tags = {
         InstanceTargetGroupTag = var.application
       }

--- a/groups/chd-infrastructure/nlb_fe_external.tf
+++ b/groups/chd-infrastructure/nlb_fe_external.tf
@@ -104,6 +104,10 @@ module "nlb_fe_external" {
         unhealthy_threshold = 3
         protocol            = "TCP"
       }
+      stickiness = {
+        type    = "source_ip"
+        enabled = true
+      }
       tags = {
         InstanceTargetGroupTag = var.application
       }

--- a/groups/chd-infrastructure/nlb_fe_external.tf
+++ b/groups/chd-infrastructure/nlb_fe_external.tf
@@ -73,6 +73,14 @@ module "nlb_fe_external" {
           port             = 80
         }
       ]
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 80
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "HTTP"
+      }
       tags = {
         InstanceTargetGroupTag = var.application
       }
@@ -88,6 +96,14 @@ module "nlb_fe_external" {
           port             = 443
         }
       ]
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 80
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "HTTP"
+      }
       tags = {
         InstanceTargetGroupTag = var.application
       }

--- a/groups/chd-infrastructure/nlb_fe_internal.tf
+++ b/groups/chd-infrastructure/nlb_fe_internal.tf
@@ -73,6 +73,14 @@ module "nlb_fe_internal" {
           port             = 80
         }
       ]
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 80
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "HTTP"
+      }
       tags = {
         InstanceTargetGroupTag = var.application
       }
@@ -88,6 +96,14 @@ module "nlb_fe_internal" {
           port             = 443
         }
       ]
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 80
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "HTTP"
+      }
       tags = {
         InstanceTargetGroupTag = var.application
       }

--- a/groups/chd-infrastructure/nlb_fe_internal.tf
+++ b/groups/chd-infrastructure/nlb_fe_internal.tf
@@ -26,42 +26,24 @@ module "nlb_fe_internal" {
 
   http_tcp_listeners = concat([
     {
-      port               = 21
+      port               = 80
       protocol           = "TCP"
       target_group_index = 0
     },
     {
-      port               = 80
+      port               = 443
       protocol           = "TCP"
       target_group_index = 1
     },
     {
-      port               = 443
+      port               = 21
       protocol           = "TCP"
       target_group_index = 2
     }
   ],
   local.chd_fe_ftp_passive_listeners)
 
-  target_groups = [
-    {
-      name                 = "tg-${var.application}-fe-internal-ftp-001"
-      backend_protocol     = "TCP"
-      backend_port         = 21
-      target_type          = "instance"
-      deregistration_delay = 10
-      health_check = {
-        enabled             = true
-        interval            = 30
-        port                = 21
-        healthy_threshold   = 3
-        unhealthy_threshold = 3
-        protocol            = "TCP"
-      }
-      tags = {
-        InstanceTargetGroupTag = var.application
-      }
-    },
+  target_groups = concat([
     {
       name                 = "tg-${var.application}-fe-internal-alb-001"
       backend_protocol     = "TCP"
@@ -107,8 +89,27 @@ module "nlb_fe_internal" {
       tags = {
         InstanceTargetGroupTag = var.application
       }
+    },
+    {
+      name                 = "tg-${var.application}-fe-internal-ftp-001"
+      backend_protocol     = "TCP"
+      backend_port         = 21
+      target_type          = "instance"
+      deregistration_delay = 10
+      health_check = {
+        enabled             = true
+        interval            = 30
+        port                = 21
+        healthy_threshold   = 3
+        unhealthy_threshold = 3
+        protocol            = "TCP"
+      }
+      tags = {
+        InstanceTargetGroupTag = var.application
+      }
     }
-  ]
+  ],
+  local.chd_fe_internal_ftp_passive_tgs)
 
   tags = merge(
     local.default_tags,

--- a/groups/chd-infrastructure/nlb_fe_internal.tf
+++ b/groups/chd-infrastructure/nlb_fe_internal.tf
@@ -86,10 +86,6 @@ module "nlb_fe_internal" {
         unhealthy_threshold = 3
         protocol            = "HTTP"
       }
-      stickiness = {
-        type    = "source_ip"
-        enabled = true
-      }
       tags = {
         InstanceTargetGroupTag = var.application
       }

--- a/groups/chd-infrastructure/nlb_fe_internal.tf
+++ b/groups/chd-infrastructure/nlb_fe_internal.tf
@@ -86,6 +86,10 @@ module "nlb_fe_internal" {
         unhealthy_threshold = 3
         protocol            = "HTTP"
       }
+      stickiness = {
+        type    = "source_ip"
+        enabled = true
+      }
       tags = {
         InstanceTargetGroupTag = var.application
       }

--- a/groups/chd-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chd-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -24,6 +24,9 @@ fe_public_access_cidrs = [
   "127.0.0.1/32"
 ]
 
+fe_ftp_passive_ports_start = 65401
+fe_ftp_passive_ports_end   = 65410
+
 fe_cw_logs = {
   "audit.log" = {
     file_path = "/var/log/audit"

--- a/groups/chd-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chd-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -24,8 +24,8 @@ fe_public_access_cidrs = [
   "127.0.0.1/32"
 ]
 
-fe_ftp_passive_ports_start = 65401
-fe_ftp_passive_ports_end   = 65410
+fe_ftp_passive_ports_start = 60401
+fe_ftp_passive_ports_end   = 60410
 
 fe_cw_logs = {
   "audit.log" = {

--- a/groups/chd-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chd-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -24,6 +24,9 @@ fe_public_access_cidrs = [
   "127.0.0.1/32"
 ]
 
+fe_ftp_passive_ports_start = 65401
+fe_ftp_passive_ports_end   = 65410
+
 fe_cw_logs = {
   "audit.log" = {
     file_path = "/var/log/audit"

--- a/groups/chd-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chd-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -24,8 +24,8 @@ fe_public_access_cidrs = [
   "127.0.0.1/32"
 ]
 
-fe_ftp_passive_ports_start = 65401
-fe_ftp_passive_ports_end   = 65410
+fe_ftp_passive_ports_start = 60401
+fe_ftp_passive_ports_end   = 60410
 
 fe_cw_logs = {
   "audit.log" = {

--- a/groups/chd-infrastructure/variables.tf
+++ b/groups/chd-infrastructure/variables.tf
@@ -218,12 +218,12 @@ variable "fe_access_cidrs" {
 
 variable "fe_ftp_passive_ports_start" {
   type        = number
-  default     = 65401
+  default     = 60401
   description = "The starting port that will define the range of ports used for FTP passive mode"
 }
 
 variable "fe_ftp_passive_ports_end" {
   type        = number
-  default     = 65440
+  default     = 60440
   description = "The ending port that will define the range of ports used for FTP passive mode"
 }


### PR DESCRIPTION
Updated ALB security group to permit HTTP and HTTPS from the NLBs for NLB healthchecks.
Properly defined healthcheck configuration to match what the target ALB is expecting.
Added new locals to dynamically build a list of Target Groups based on the passive FTP port range specified (1 TG per port)
Reordered listeners and TGs to place `alb` listeners first
Replaced indexed local with a loop to ensure all ASG instances are properly registered to all FTP target groups
Added dev and staging vars to limit the number of passive ports for testing purposes
Added stickyness configuration to FTP target groups