### PR TITLE
Add htdocs Symlink and send FTP log to CloudWatch

### DIFF
--- a/groups/chd-infrastructure/data.tf
+++ b/groups/chd-infrastructure/data.tf
@@ -140,6 +140,7 @@ data "template_file" "fe_userdata" {
     HERITAGE_ENVIRONMENT = title(var.environment)
     CHD_FRONTEND_INPUTS  = local.chd_fe_data
     ANSIBLE_INPUTS       = jsonencode(local.chd_fe_ansible_inputs)
+    ONLINE_MOUNT_PATH    = var.fe_online_mount_path
   }
 }
 

--- a/groups/chd-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/chd-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -70,6 +70,11 @@ fe_cw_logs = {
     file_path = "/etc/httpd/logs"
     log_group_retention = 7
   }
+
+  "ftp_xfer_log" = {
+    file_path = "/var/log/xferlog"
+    log_group_retention = 7
+  }
 }
 
 # ------------------------------------------------------------------------------

--- a/groups/chd-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chd-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -18,6 +18,8 @@ fe_asg_min_size = 2
 fe_asg_max_size = 2
 fe_asg_desired_capacity = 2
 
+fe_online_mount_path = "/mnt/nfs/onsite/chd/online"
+
 fe_public_access_cidrs = [
   "0.0.0.0/0"
 ]
@@ -60,6 +62,11 @@ fe_cw_logs = {
 
   "chd_error_log" = {
     file_path = "/etc/httpd/logs"
+    log_group_retention = 7
+  }
+
+  "ftp_xfer_log" = {
+    file_path = "/var/log/xferlog"
     log_group_retention = 7
   }
 }

--- a/groups/chd-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/chd-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -70,6 +70,11 @@ fe_cw_logs = {
     file_path = "/etc/httpd/logs"
     log_group_retention = 7
   }
+
+  "ftp_xfer_log" = {
+    file_path = "/var/log/xferlog"
+    log_group_retention = 7
+  }
 }
 
 # ------------------------------------------------------------------------------

--- a/groups/chd-infrastructure/templates/fe_user_data.tpl
+++ b/groups/chd-infrastructure/templates/fe_user_data.tpl
@@ -23,6 +23,8 @@ rm /etc/httpd/conf.d/perl.conf
 /usr/local/bin/j2 -f json /etc/httpd/conf.d/chd_perl.conf.j2 inputs.json > /etc/httpd/conf.d/chd_perl.conf
 #Run Ansible playbook for Frontend deployment using provided inputs
 /usr/local/bin/ansible-playbook /root/frontend_deployment.yml -e '${ANSIBLE_INPUTS}'
+#Create htdocs symlink
+ln -s ${ONLINE_MOUNT_PATH} /home/chd/htdocs/chd3/static/online
 # Update hostname and reboot
 INSTANCEID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
 sed -i "s/HOSTNAME=.*/HOSTNAME=$INSTANCEID/" /etc/sysconfig/network

--- a/groups/chd-infrastructure/variables.tf
+++ b/groups/chd-infrastructure/variables.tf
@@ -245,3 +245,9 @@ variable "fe_ftp_root_dir" {
   default     = "/mnt/nfs/onsite/chd/"
   description = "Path for the FTP server's root directory"
 }
+
+variable "fe_online_mount_path" {
+  type        = string
+  default     = "/mnt/nfs/chd/online"
+  description = "Path to the online NFS mount"
+}


### PR DESCRIPTION
Updated frontend user_data template to create a required symlink within the static htdocs structure
Added new var to support configuration of the symlink target
Added profile vars to capture FTP xferlog and send it to CloudWatch