### PR TITLE
Allow access from test subnets in Live

### DIFF
--- a/groups/chd-infrastructure/alb_internal.tf
+++ b/groups/chd-infrastructure/alb_internal.tf
@@ -11,7 +11,8 @@ module "chd_internal_alb_security_group" {
 
   ingress_cidr_blocks = concat(
     local.admin_cidrs,
-    formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_internal : eni.private_ip])
+    formatlist("%s/32", [for eni in data.aws_network_interface.nlb_fe_internal : eni.private_ip]),
+    local.test_cidrs
   )
 
   ingress_rules       = ["http-80-tcp", "https-443-tcp"]

--- a/groups/chd-infrastructure/data.tf
+++ b/groups/chd-infrastructure/data.tf
@@ -67,6 +67,10 @@ data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }
 
+data "vault_generic_secret" "test_cidrs" {
+  path = "aws-accounts/network/shared-services/test_cidr_ranges"
+}
+
 data "vault_generic_secret" "kms_keys" {
   path = "aws-accounts/${var.aws_account}/kms"
 }

--- a/groups/chd-infrastructure/locals.tf
+++ b/groups/chd-infrastructure/locals.tf
@@ -3,6 +3,7 @@
 # ------------------------------------------------------------------------
 locals {
   admin_cidrs = values(data.vault_generic_secret.internal_cidrs.data)
+  test_cidrs  = var.test_access_enable ? jsondecode(data.vault_generic_secret.test_cidrs.data["cidrs"]) : []
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 

--- a/groups/chd-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/chd-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -152,3 +152,5 @@ nfs_mounts = {
     nfs_server_address = "ipo-file-svm-lif-be1.internal.ch"
   }
 }
+
+test_access_enable = true

--- a/groups/chd-infrastructure/variables.tf
+++ b/groups/chd-infrastructure/variables.tf
@@ -251,3 +251,9 @@ variable "fe_online_mount_path" {
   default     = "/mnt/nfs/chd/online"
   description = "Path to the online NFS mount"
 }
+
+variable "test_access_enable" {
+  type        = bool
+  description = "Controls whether access from the Test subnets is required (true) or not (false)"
+  default     = false
+}


### PR DESCRIPTION
Added support to optionally allow access from test subnets via internal ALB
Added local to conditionally construct the list of CIDRs
Updated internal ALB SG to include the CIDRs
Enabled access for Live

Resolves: INC0365535