### PR TITLE
Compress cron entries so they fit in parameter store

### DIFF
--- a/groups/chd-infrastructure/locals.tf
+++ b/groups/chd-infrastructure/locals.tf
@@ -152,6 +152,6 @@ locals {
     frontend_ansible_inputs = jsonencode(local.chd_fe_ansible_inputs)
     backend_inputs          = local.chd_bep_data
     backend_ansible_inputs  = jsonencode(local.chd_bep_ansible_inputs)
-    backend_cron_entries    = data.template_file.chd_cron_file.rendered
+    backend_cron_entries    = base64gzip(data.template_file.chd_cron_file.rendered)
   }
 }

--- a/groups/chd-infrastructure/templates/bep_user_data.tpl
+++ b/groups/chd-infrastructure/templates/bep_user_data.tpl
@@ -7,7 +7,7 @@ GET_PARAM_COMMAND="/usr/local/bin/aws ssm get-parameter --with-decryption --regi
 #Create key:value variable
 $${GET_PARAM_COMMAND} '${CHD_BACKEND_INPUTS_PATH}' > inputs.json
 #Create cron file and set crontab for CHD user:
-$${GET_PARAM_COMMAND} '${CHD_CRON_ENTRIES_PATH}' > /root/cronfile
+$${GET_PARAM_COMMAND} '${CHD_CRON_ENTRIES_PATH}' | base64 -d | gunzip > /root/cronfile
 crontab -u chd /root/cronfile
 #Set DATABASE environment variable
 echo "export DATABASE=ORACLE" >> /home/chd/.bash_profile


### PR DESCRIPTION
The cron entries for live are too large to fit in parameter store as they stand, so this PR adds a change to compress/uncompress the data so that it fits.

https://companieshouse.atlassian.net/browse/DVOP-2679